### PR TITLE
Make highfive post the test failures from homu

### DIFF
--- a/handlers/homu_status/__init__.py
+++ b/handlers/homu_status/__init__.py
@@ -1,7 +1,6 @@
 from eventhandler import EventHandler
 import json
 import re
-import urllib2
 
 def check_failure_log(api, bors_comment):
     # bors_comment would be something like,
@@ -13,8 +12,8 @@ def check_failure_log(api, bors_comment):
 
     # substitute and get the new url - http://build.servo.org/json/builders/linux2/builds/2627
     json_url = re.sub(r'(.*)(builders/.*)', r'\1json/\2', url)
-    fd = urllib2.urlopen(json_url)
-    build_stats = json.loads(fd.read())
+    json_stuff = api.get_page_content(json_url)
+    build_stats = json.loads(json_stuff)
 
     build_log = []
     for step in build_stats['steps']:
@@ -31,8 +30,7 @@ def check_failure_log(api, bors_comment):
     if not failed_url:
         return
 
-    fd = urllib2.urlopen(failed_url)
-    stdio = fd.read()
+    stdio = api.get_page_content(failed_url)
     failures = iter(re.findall(r'.*Tests with unexpected results:\n(.*)\n</span><span',
                                stdio, re.DOTALL)).next()
     if failures:

--- a/handlers/homu_status/__init__.py
+++ b/handlers/homu_status/__init__.py
@@ -1,4 +1,44 @@
 from eventhandler import EventHandler
+import json
+import re
+import urllib2
+
+def check_failure_log(api, bors_comment):
+    # bors_comment would be something like,
+    # ":broken_heart: Test failed - [linux2](http://build.servo.org/builders/linux2/builds/2627)"
+    # ... from which we get the relevant build result url
+    url = iter(re.findall(r'.*\((.*)\)', bors_comment)).next()
+    if not url:
+        return
+
+    # substitute and get the new url - http://build.servo.org/json/builders/linux2/builds/2627
+    json_url = re.sub(r'(.*)(builders/.*)', r'\1json/\2', url)
+    fd = urllib2.urlopen(json_url)
+    build_stats = json.loads(fd.read())
+
+    build_log = []
+    for step in build_stats['steps']:
+        if 'failed' in step['text']:
+            build_log = step['logs']
+            break
+
+    failed_url = None
+    for (name, log_url) in build_log:
+        if name == 'stdio':
+            failed_url = log_url
+            break
+
+    if not failed_url:
+        return
+
+    fd = urllib2.urlopen(failed_url)
+    stdio = fd.read()
+    failures = iter(re.findall(r'.*Tests with unexpected results:\n(.*)\n</span><span',
+                               stdio, re.DOTALL)).next()
+    if failures:
+        comment_body = '\n'.join(map(lambda line: ' ' * 4 + line, failures.split('\n')))
+        api.post_comment(comment_body)
+
 
 class HomuStatusHandler(EventHandler):
     def on_new_comment(self, api, payload):
@@ -25,6 +65,8 @@ class HomuStatusHandler(EventHandler):
         elif 'Test failed' in msg:
             remove_if_exists("S-awaiting-merge")
             api.add_label("S-tests-failed")
+            # get the homu build stats url, extract the failed tests and post them!
+            check_failure_log(api, msg)
 
         elif 'Please resolve the merge conflicts' in msg:
             remove_if_exists("S-awaiting-merge")

--- a/handlers/homu_status/tests/json/builders/test_builder_result.json
+++ b/handlers/homu_status/tests/json/builders/test_builder_result.json
@@ -1,0 +1,8 @@
+{
+    "steps": [{
+        "logs": [
+            ["stdio", "handlers/homu_status/tests/json/builders/test_stdio"]
+        ],
+        "text": ["test", "failed"]
+    }]
+}

--- a/handlers/homu_status/tests/json/builders/test_stdio
+++ b/handlers/homu_status/tests/json/builders/test_stdio
@@ -1,0 +1,12 @@
+// fooooooooooooo barrrrrrrrrrrrrrrrrrr
+
+Tests with unexpected results:
+  ▶ OK [expected CRASH] /something/foo/something.html
+
+  ▶ Unexpected subtest result in /something/blah/something.html
+  │ FAIL [expected PASS] totally-something-else
+  │
+  │ reporting...
+  └ I won't report anymore...
+
+</span><span>

--- a/handlers/homu_status/tests/tests_failed.json
+++ b/handlers/homu_status/tests/tests_failed.json
@@ -3,7 +3,8 @@
       "labels": ["S-awaiting-merge"]
   },
   "expected": {
-      "labels": ["S-tests-failed"]
+      "labels": ["S-tests-failed"],
+      "comments": 1
   },
   "payload":
 {
@@ -85,7 +86,7 @@
     },
     "created_at": "2015-08-07T16:45:57Z",
     "updated_at": "2015-08-07T16:45:57Z",
-    "body": ":broken_heart: Test failed - [linux2](http://build.servo.org/builders/linux2/builds/2627)"
+    "body": ":broken_heart: Test failed - [linux2](handlers/homu_status/tests/builders/test_builder_result.json)"
   },
   "repository": {
     "id": 3390243,

--- a/newpr.py
+++ b/newpr.py
@@ -48,6 +48,9 @@ class APIProvider:
     def get_pull(self):
         raise NotImplementedError
 
+    def get_page_content(self, url):
+        raise NotImplementedError
+
 
 class GithubAPIProvider(APIProvider):
     contributors_url = "https://api.github.com/repos/%s/%s/contributors?per_page=400"
@@ -193,6 +196,10 @@ class GithubAPIProvider(APIProvider):
 
     def get_pull(self):
         return self.api_req("GET", self.pull_url)["body"]
+
+    def get_page_content(self, url):
+        with urllib2.urlopen(url) as fd:
+            return fd.read()
 
 
 warning_summary = '<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>\n\n%s'

--- a/test.py
+++ b/test.py
@@ -38,6 +38,11 @@ class TestAPIProvider(APIProvider):
     def set_assignee(self, assignee):
         self.assignee = assignee
 
+    def get_page_content(self, path):
+        with open(path) as fd:
+            return fd.read()
+
+
 def get_payload(filename):
     with open(filename) as f:
         return json.load(f)


### PR DESCRIPTION
This makes use of homu's JSON API to get the test output from stdout and comment on the PR in the event of a test failure.

@jdm I didn't make use of the error summary log, because there seem to be some discrepancies between stdout and the log. For instance, the log doesn't have the stacktraces sometimes<sup>[1]</sup>.

We need the stacktraces because:
1) we need the whole log related to the failure (so that we don't have to visit the `stdio` page again
2) we can make highfive more intelligent (in the near future) by posting "retry" messages to @bors-servo referencing the relevant intermittent issues or opening a new issue (which will save more time for us!), and for opening new intermittent-related issues, we'll be needing the stacktrace.

<sup>[1]: See this build's [stdout](http://build.servo.org/builders/mac-rel-wpt/builds/459/steps/shell_2/logs/stdio) and the corresponding [error summary log](http://build.servo.org/builders/mac-rel-wpt/builds/459/steps/shell_2/logs/wpt_errorsummary.log)</sup>