### PR TITLE
urllib2.urlopen should be properly closed to avoid exceptions

### DIFF
--- a/handlers/homu_status/__init__.py
+++ b/handlers/homu_status/__init__.py
@@ -13,6 +13,9 @@ def check_failure_log(api, bors_comment):
     # substitute and get the new url - http://build.servo.org/json/builders/linux2/builds/2627
     json_url = re.sub(r'(.*)(builders/.*)', r'\1json/\2', url)
     json_stuff = api.get_page_content(json_url)
+    if not json_stuff:
+        return
+
     build_stats = json.loads(json_stuff)
 
     build_log = []

--- a/newpr.py
+++ b/newpr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import base64
+import contextlib
 import eventhandler
 import urllib, urllib2
 import cgi
@@ -198,8 +199,11 @@ class GithubAPIProvider(APIProvider):
         return self.api_req("GET", self.pull_url)["body"]
 
     def get_page_content(self, url):
-        with urllib2.urlopen(url) as fd:
-            return fd.read()
+        try:
+            with contextlib.closing(urllib2.urlopen(url)) as fd:
+                return fd.read()
+        except urllib2.URLError:
+            return None
 
 
 warning_summary = '<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>\n\n%s'


### PR DESCRIPTION
`get_page_content` seemed to throw an exception when I tried locally. It turned out that `with` actually calls the `__enter__` and `__exit__` methods on a file descriptor. While `file` has those methods, `urlopen` doesn't (which explains why the tests passed locally) - it always throws an `AttributeError`. This should just work if the thing's properly closed.