### PR TITLE
Highfive intelligence treatment: basics to find intermittents

### DIFF
--- a/handlers/homu_status/__init__.py
+++ b/handlers/homu_status/__init__.py
@@ -5,6 +5,46 @@ import re
 
 from eventhandler import EventHandler
 
+WPT_RESULT_ARROW = '\xe2\x96\xb6'
+
+
+def parse_log(log):     # gets the names of the failed tests
+    test_names = []
+    l = log.split()
+    for i, thing in enumerate(l):
+        if thing == WPT_RESULT_ARROW:
+            # We can blindly index the results here, because we can rely
+            # on the WPT output. It has the unexpected result, expected result
+            # and the test path following that unicode character
+            name = l[i + 4].split('/')[-1]
+            test_names.append(name)
+    return test_names
+
+
+def get_failed_url(json_obj):
+    if not json_obj:
+        return
+
+    build_stats = json.loads(json_obj)
+    build_log = []
+    for step in build_stats['steps']:
+        if 'failed' in step['text']:
+            build_log = step['logs']
+            break
+
+    for (name, log_url) in build_log:
+        if name == 'stdio':
+            failed_url = log_url
+            return failed_url
+
+
+def get_known_intermittents(api, test_names):
+    known_fails = set()     # so that we don't have duplicates
+    for name in test_names:
+        for issue in api.get_intermittents(name):
+            known_fails.add(issue['number'])
+    return known_fails
+
 
 def check_failure_log(api, bors_comment):
     # bors_comment would be something like,
@@ -18,32 +58,31 @@ def check_failure_log(api, bors_comment):
     # (e.g. http://build.servo.org/json/builders/linux2/builds/2627)
     json_url = re.sub(r'(.*)(builders/.*)', r'\1json/\2', url)
     json_stuff = api.get_page_content(json_url)
-    if not json_stuff:
-        return
-
-    build_stats = json.loads(json_stuff)
-
-    build_log = []
-    for step in build_stats['steps']:
-        if 'failed' in step['text']:
-            build_log = step['logs']
-            break
-
-    failed_url = None
-    for (name, log_url) in build_log:
-        if name == 'stdio':
-            failed_url = log_url
-            break
-
+    failed_url = get_failed_url(json_stuff)
     if not failed_url:
         return
 
     stdio = api.get_page_content(failed_url)
     failure_regex = r'.*Tests with unexpected results:\n(.*)\n</span><span'
     failures = iter(re.findall(failure_regex, stdio, re.DOTALL)).next()
-    if failures:
-        comments = [' ' * 4 + line for line in failures.split('\n')]
-        api.post_comment('\n'.join(comments))
+    if not failures:
+        return
+
+    comments = '\n'.join([' ' * 4 + line for line in failures.split('\n')])
+    test_names = parse_log(failures)
+    if not test_names:
+        return
+
+    known_fails = get_known_intermittents(api, test_names)
+    if known_fails:
+        suffix = ('The following issues exist for tests with known '
+                  'intermittent failures:\n - ') + \
+                  ' - '.join(map(lambda num: '#%s\n' % num, known_fails))
+    else:
+        suffix = ("Sorry, these test failures don't match any known "
+                  "intermittent failures.\n :disappointed_relieved:")
+
+    api.post_comment(comments + '\n\n' + suffix)
 
 
 class HomuStatusHandler(EventHandler):

--- a/handlers/homu_status/tests/intermittents.json
+++ b/handlers/homu_status/tests/intermittents.json
@@ -1,0 +1,40 @@
+{
+  "expected": {
+    "labels": [
+      "S-tests-failed"
+    ],
+    "comments": 1
+  },
+  "initial": {
+    "labels": [
+      "S-awaiting-merge"
+    ]
+  },
+  "payload": {
+    "action": "created",
+    "comment": {
+      "body": ":broken_heart: Test failed - [linux2](handlers/homu_status/tests/builders/test_builder_result.json)",
+      "user": {
+        "login": "bors-servo"
+      }
+    },
+    "search": {
+      "items": [
+        {
+          "number": 10760
+        }
+      ]
+    },
+    "issue": {
+      "number": 7075,
+      "state": "open",
+      "pull_request": {}
+    },
+    "repository": {
+      "owner": {
+        "login": "servo"
+      },
+      "name": "servo"
+    }
+  }
+}

--- a/handlers/homu_status/tests/json/builders/test_stdio
+++ b/handlers/homu_status/tests/json/builders/test_stdio
@@ -1,10 +1,10 @@
 // fooooooooooooo barrrrrrrrrrrrrrrrrrr
 
 Tests with unexpected results:
-  ▶ OK [expected CRASH] /something/foo/something.html
+  ▶ FAIL [expected PASS] /_mozilla/mozilla/sslfail.html
 
   ▶ Unexpected subtest result in /something/blah/something.html
-  │ FAIL [expected PASS] totally-something-else
+  │ OK [expected CRASH] totally-something-else
   │
   │ reporting...
   └ I won't report anymore...

--- a/newpr.py
+++ b/newpr.py
@@ -53,6 +53,9 @@ class APIProvider(object):
     def get_page_content(self, url):
         raise NotImplementedError
 
+    def get_intermittents(self, labels):
+        raise NotImplementedError
+
 
 class GithubAPIProvider(APIProvider):
     BASE_URL = "https://api.github.com/repos/"
@@ -63,6 +66,7 @@ class GithubAPIProvider(APIProvider):
     get_label_url = BASE_URL + "%s/%s/issues/%s/labels"
     add_label_url = BASE_URL + "%s/%s/issues/%s/labels"
     remove_label_url = BASE_URL + "%s/%s/issues/%s/labels/%s"
+    search_url = "https://api.github.com/search/issues?q=user:%s+repo:%s"
 
     def __init__(self, payload, user, token):
         APIProvider.__init__(self, payload, user)
@@ -206,6 +210,13 @@ class GithubAPIProvider(APIProvider):
                 return fd.read()
         except urllib2.URLError:
             return None
+
+    def get_intermittents(self, title):
+        filters = ['in:title', 'is:issue', 'label:I-intermittent']
+        query = [self.search_url % (self.owner, self.repo), title]
+        query.extend(filters)
+        result = self.api_req("GET", '+'.join(query))
+        return result['items']
 
 
 img = ('<img src="http://www.joshmatthews.net/warning.svg" '

--- a/test.py
+++ b/test.py
@@ -22,6 +22,8 @@ class TestAPIProvider(APIProvider):
         self.diff = diff
         self.pull_request = pull_request
         self.repo = str(self.repo)      # workaround for testing
+        self.search_results = payload['search'] if 'search' in payload \
+            else {'items': []}
 
     def is_new_contributor(self, username):
         return self.new_contributor
@@ -50,6 +52,9 @@ class TestAPIProvider(APIProvider):
     def get_page_content(self, path):
         with open(path) as fd:
             return fd.read()
+
+    def get_intermittents(self, labels):
+        return self.search_results['items']
 
 
 def create_test(filename, initial, expected,
@@ -113,10 +118,11 @@ def run_tests(tests, warn=True, overwrite=False):
                 if overwrite:   # useful for cleaning up the tests locally
                     clean_dict = test['dict']
                     clean_dict['payload'] = cleaned['payload']
-                    with open(test['filename'], 'w') as fd:
-                        json.dump(clean_dict, fd, indent=2)
-                    error = '\033[91m%s\033[0m: Rewrote the JSON file'
-                    print(error % test['filename'])
+                    if wrapper.unused:
+                        with open(test['filename'], 'w') as fd:
+                            json.dump(clean_dict, fd, indent=2)
+                        message = '\033[91m%s\033[0m: Rewrote the JSON file'
+                        print(message % test['filename'])
 
         except AssertionError as error:
             _, _, tb = sys.exc_info()

--- a/test.py
+++ b/test.py
@@ -73,7 +73,7 @@ def create_test(filename, initial, expected,
 
 
 def run_tests(tests, warn=True, overwrite=False):
-    failed = 0
+    failed, dirty = 0, 0
     for handler, test in tests:
         eventhandler.reset_test_state()
 
@@ -108,7 +108,7 @@ def run_tests(tests, warn=True, overwrite=False):
                 if wrapper.unused and not overwrite:
                     error = '\033[91m%s\033[0m: The file has %s unused nodes'
                     print(error % (test['filename'], wrapper.unused))
-                    failed += 1
+                    dirty += 1
 
                 if overwrite:   # useful for cleaning up the tests locally
                     clean_dict = test['dict']
@@ -129,10 +129,7 @@ def run_tests(tests, warn=True, overwrite=False):
             print(error)
             failed += 1
 
-    print('Ran %d tests, %d failed' % (len(tests), failed))
-
-    if failed:
-        sys.exit(1)
+    return failed, dirty
 
 
 def register_tests(path):
@@ -183,4 +180,12 @@ if __name__ == "__main__":
     overwrite = True if 'write' in args else False
 
     tests = setup_tests()
-    run_tests(tests, not overwrite, overwrite)
+    failed, dirty = run_tests(tests, not overwrite, overwrite)
+
+    print('Ran %d tests, %d failed, %d file(s) dirty' %
+          (len(tests), failed, dirty))
+
+    if failed or dirty:
+        if dirty:
+            print('Run `python %s write` to cleanup the dirty files' % args)
+        sys.exit(1)


### PR DESCRIPTION
This should help in showing known intermittents next to the logs if we find a matching file in the title of issues tagged under "I-intermittent".

@jdm I wasn't sure about testing this initially, because we don't have a handler (and hence, a test) that fiddles around the payload response for a search query (currently, all our handlers work on PRs). So, I went ahead and crafted one for the sake of testing this. Realistically, when we query something, the API [returns something similar](https://developer.github.com/v3/search/#search-issues) to what we have in `payload['search']`.
