### PR TITLE
Include handler with its associated tests

### DIFF
--- a/newpr.py
+++ b/newpr.py
@@ -226,8 +226,9 @@ def extract_globals_from_payload(payload):
     return (owner, repo, issue)
 
 
-def handle_payload(api, payload):
-    (modules, handlers) = eventhandler.get_handlers()
+def handle_payload(api, payload, handlers=None):
+    if not handlers:
+        modules, handlers = eventhandler.get_handlers()
     for handler in handlers:
         handler.handle_payload(api, payload)
     warnings = eventhandler.get_warnings()

--- a/test.py
+++ b/test.py
@@ -84,7 +84,7 @@ def run_tests(tests):
                                   initial['assignee'],
                                   initial['diff'],
                                   initial['pull_request'])
-            handle_payload(api, payload)
+            handle_payload(api, payload, [handler])
             expected = test['expected']
             if 'comments' in expected:
                 assert len(api.comments_posted) == expected['comments'], \

--- a/test.py
+++ b/test.py
@@ -71,7 +71,7 @@ def create_test(filename, initial, expected):
 
 def run_tests(tests):
     failed = 0
-    for test in tests:
+    for handler, test in tests:
         eventhandler.reset_test_state()
 
         try:
@@ -135,7 +135,8 @@ def setup_tests():
     (modules, handlers) = eventhandler.get_handlers()
     tests = []
     for module, handler in zip(modules, handlers):
-        tests.extend(register_tests(module[1]))
+        for test in register_tests(module[1]):
+            tests.append((handler, test))
     return tests
 
 


### PR DESCRIPTION
Include handler with its associated tests. This way, a test will only target a specific handler instead of executing all handlers
fixes #117 