### PR TITLE
Consolidate diff parsing logic

### DIFF
--- a/eventhandler.py
+++ b/eventhandler.py
@@ -67,7 +67,7 @@ class EventHandler:
 
         # Remove the `a/` and `b/` parts of paths,
         # And get unique values using `set()`
-        return set(map(lambda f: f if f.startswith('/') else f[2:], changed_files))
+        return set(f if f.startswith('/') else f[2:] for f in changed_files)
 
 
 def reset_test_state():

--- a/eventhandler.py
+++ b/eventhandler.py
@@ -49,13 +49,13 @@ class EventHandler:
 
     def get_diff_headers(self, api):
         diff = api.get_diff()
-        for line in diff.split('\n'):
+        for line in diff.splitlines():
             if line.startswith(DIFF_HEADER_LINE_START):
                 yield line
 
     def get_added_lines(self, api):
         diff = api.get_diff()
-        for line in diff.split('\n'):
+        for line in diff.splitlines():
             if line.startswith('+') and not line.startswith('+++'):
                 # prefix of one or two pluses (+)
                 yield line

--- a/eventhandler.py
+++ b/eventhandler.py
@@ -45,6 +45,18 @@ class EventHandler:
                 'pull_request' in payload['issue'])
 
 
+    def get_changed_files(self, api):
+        changed_files = []
+        diff = api.get_diff()
+        for line in diff.split('\n'):
+            if line.startswith('diff --git'):
+                changed_files.extend(line.split('diff --git ')[-1].split(' '))
+
+        # Remove the `a/` and `b/` parts of paths,
+        # And get unique values using `set()`
+        return set(map(lambda f: f if f.startswith('/') else f[2:], changed_files))
+
+
 def reset_test_state():
     global _warnings
     _warnings = []

--- a/eventhandler.py
+++ b/eventhandler.py
@@ -53,6 +53,13 @@ class EventHandler:
             if line.startswith(DIFF_HEADER_LINE_START):
                 yield line
 
+    def get_added_lines(self, api):
+        diff = api.get_diff()
+        for line in diff.split('\n'):
+            if line.startswith('+') and not line.startswith('+++'):
+                # prefix of one or two pluses (+)
+                yield line
+
     def get_changed_files(self, api):
         changed_files = []
         for line in self.get_diff_headers(api):

--- a/eventhandler.py
+++ b/eventhandler.py
@@ -13,6 +13,8 @@ _payload_actions = {
     'labeled': 'on_issue_labeled'
 }
 
+DIFF_HEADER_LINE_START = 'diff --git '
+
 
 class EventHandler:
     def on_pr_opened(self, api, payload):
@@ -45,12 +47,16 @@ class EventHandler:
                 'pull_request' in payload['issue'])
 
 
-    def get_changed_files(self, api):
-        changed_files = []
+    def get_diff_headers(self, api):
         diff = api.get_diff()
         for line in diff.split('\n'):
-            if line.startswith('diff --git'):
-                changed_files.extend(line.split('diff --git ')[-1].split(' '))
+            if line.startswith(DIFF_HEADER_LINE_START):
+                yield line
+
+    def get_changed_files(self, api):
+        changed_files = []
+        for line in self.get_diff_headers(api):
+            changed_files.extend(line.split(DIFF_HEADER_LINE_START)[-1].split(' '))
 
         # Remove the `a/` and `b/` parts of paths,
         # And get unique values using `set()`

--- a/eventhandler.py
+++ b/eventhandler.py
@@ -12,9 +12,6 @@ _payload_actions = {
     'closed': 'on_pr_closed',
     'labeled': 'on_issue_labeled'
 }
-_test_path_roots = ['a/', 'b/']
-
-DIFF_HEADER_LINE_START = 'diff --git '
 
 
 class EventHandler:
@@ -46,36 +43,6 @@ class EventHandler:
     def is_open_pr(self, payload):
         return (payload['issue']['state'] == 'open' and
                 'pull_request' in payload['issue'])
-
-
-    def get_diff_headers(self, api):
-        diff = api.get_diff()
-        for line in diff.splitlines():
-            if line.startswith(DIFF_HEADER_LINE_START):
-                yield line
-
-    def get_added_lines(self, api):
-        diff = api.get_diff()
-        for line in diff.splitlines():
-            if line.startswith('+') and not line.startswith('+++'):
-                # prefix of one or two pluses (+)
-                yield line
-
-    def get_changed_files(self, api):
-        changed_files = []
-        for line in self.get_diff_headers(api):
-            changed_files.extend(line.split(DIFF_HEADER_LINE_START)[-1].split(' '))
-
-        # And get unique values using `set()`
-        return set(f for f in map(self.normalize_file_path, changed_files) if f is not None)
-
-    def normalize_file_path(self, filepath):
-        if filepath is None or filepath.strip() == '':
-            return None
-        for prefix in _test_path_roots:
-            if filepath.startswith(prefix):
-                return filepath[len(prefix):]
-        return filepath
 
 
 def reset_test_state():

--- a/handlers/empty_title_element/__init__.py
+++ b/handlers/empty_title_element/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
-
 from eventhandler import EventHandler
-from helpers import is_addition
 
 WARNING = ("These commits include an empty title element (`<title></title>`). "
            "Consider adding appropriate metadata.")
@@ -9,9 +7,8 @@ WARNING = ("These commits include an empty title element (`<title></title>`). "
 
 class EmptyTitleElementHandler(EventHandler):
     def on_pr_opened(self, api, payload):
-        diff = api.get_diff()
-        for line in diff.split('\n'):
-            if is_addition(line) and line.find("<title></title>") > -1:
+        for line in api.get_added_lines():
+            if line.find("<title></title>") > -1:
                 # This test doesn't consider case and whitespace the same way
                 # that a HTML parser does, so empty title elements might still
                 # go unnoticed. It will catch the low-hanging fruit, though.

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -14,7 +14,7 @@ class MissingTestHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         components_changed = set()
 
-        for line in api.get_diff_headers():
+        for line in api.get_changed_files():
             for component in self.COMPONENT_DIRS_TO_CHECK:
                 if 'components/{0}/'.format(component) in line:
                     components_changed.add(component)

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -6,7 +6,6 @@ TEST_REQUIRED_MSG = ('These commits modify {} code, but no tests are modified.'
                      ' Please consider adding a test!')
 
 
-
 class MissingTestHandler(EventHandler):
     COMPONENT_DIRS_TO_CHECK = ('layout', 'script', 'gfx', 'style', 'net')
     TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit')

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -14,13 +14,13 @@ class MissingTestHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         components_changed = set()
 
-        for line in api.get_changed_files():
+        for filepath in api.get_changed_files():
             for component in self.COMPONENT_DIRS_TO_CHECK:
-                if 'components/{0}/'.format(component) in line:
+                if 'components/{0}/'.format(component) in filepath:
                     components_changed.add(component)
 
             for directory in self.TEST_DIRS_TO_CHECK:
-                if 'tests/{0}'.format(directory) in line:
+                if 'tests/{0}'.format(directory) in filepath:
                     return
 
         if components_changed:

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -14,7 +14,7 @@ class MissingTestHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         components_changed = set()
 
-        for line in self.get_diff_headers(api):
+        for line in api.get_diff_headers():
             for component in self.COMPONENT_DIRS_TO_CHECK:
                 if 'components/{0}/'.format(component) in line:
                     components_changed.add(component)

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -6,23 +6,22 @@ TEST_REQUIRED_MSG = ('These commits modify {} code, but no tests are modified.'
                      ' Please consider adding a test!')
 
 
+
 class MissingTestHandler(EventHandler):
     COMPONENT_DIRS_TO_CHECK = ('layout', 'script', 'gfx', 'style', 'net')
     TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit')
 
     def on_pr_opened(self, api, payload):
-        diff = api.get_diff()
         components_changed = set()
 
-        for line in diff.split('\n'):
-            if line.startswith('diff --git'):
-                for component in self.COMPONENT_DIRS_TO_CHECK:
-                    if 'components/{0}/'.format(component) in line:
-                        components_changed.add(component)
+        for line in self.get_diff_headers(api):
+            for component in self.COMPONENT_DIRS_TO_CHECK:
+                if 'components/{0}/'.format(component) in line:
+                    components_changed.add(component)
 
-                for directory in self.TEST_DIRS_TO_CHECK:
-                    if 'tests/{0}'.format(directory) in line:
-                        return
+            for directory in self.TEST_DIRS_TO_CHECK:
+                if 'tests/{0}'.format(directory) in line:
+                    return
 
         if components_changed:
             # Build a readable list of changed components

--- a/handlers/no_modify_css_tests/__init__.py
+++ b/handlers/no_modify_css_tests/__init__.py
@@ -11,8 +11,8 @@ class NoModifyCSSTestsHandler(EventHandler):
     DIR_TO_CHECK = "tests/wpt/css-tests"
 
     def on_pr_opened(self, api, payload):
-        for line in api.get_diff().split('\n'):
-            if line.startswith("diff --git") and self.DIR_TO_CHECK in line:
+        for line in self.get_diff_headers(api):
+            if self.DIR_TO_CHECK in line:
                 self.warn(NO_MODIFY_CSS_TESTS_MSG)
                 break
 

--- a/handlers/no_modify_css_tests/__init__.py
+++ b/handlers/no_modify_css_tests/__init__.py
@@ -11,8 +11,8 @@ class NoModifyCSSTestsHandler(EventHandler):
     DIR_TO_CHECK = "tests/wpt/css-tests"
 
     def on_pr_opened(self, api, payload):
-        for line in api.get_changed_files():
-            if self.DIR_TO_CHECK in line:
+        for filepath in api.get_changed_files():
+            if self.DIR_TO_CHECK in filepath:
                 self.warn(NO_MODIFY_CSS_TESTS_MSG)
                 break
 

--- a/handlers/no_modify_css_tests/__init__.py
+++ b/handlers/no_modify_css_tests/__init__.py
@@ -11,7 +11,7 @@ class NoModifyCSSTestsHandler(EventHandler):
     DIR_TO_CHECK = "tests/wpt/css-tests"
 
     def on_pr_opened(self, api, payload):
-        for line in self.get_diff_headers(api):
+        for line in api.get_diff_headers():
             if self.DIR_TO_CHECK in line:
                 self.warn(NO_MODIFY_CSS_TESTS_MSG)
                 break

--- a/handlers/no_modify_css_tests/__init__.py
+++ b/handlers/no_modify_css_tests/__init__.py
@@ -11,7 +11,7 @@ class NoModifyCSSTestsHandler(EventHandler):
     DIR_TO_CHECK = "tests/wpt/css-tests"
 
     def on_pr_opened(self, api, payload):
-        for line in api.get_diff_headers():
+        for line in api.get_changed_files():
             if self.DIR_TO_CHECK in line:
                 self.warn(NO_MODIFY_CSS_TESTS_MSG)
                 break

--- a/handlers/nonini_wpt_meta/__init__.py
+++ b/handlers/nonini_wpt_meta/__init__.py
@@ -18,19 +18,16 @@ class NonINIWPTMetaFileHandler(EventHandler):
         'mozilla-sync',
     )
 
-    def _wpt_ini_dirs(self, line):
-        if line.startswith('diff --git') and '.' in line \
-           and not any(fp in line for fp in self.FALSE_POSITIVE_SUBSTRINGS):
-            return set(directory for directory in self.DIRS_TO_CHECK
-                       if directory in line)
+    def _wpt_ini_dirs(self, diff_line):
+        if '.' in diff_line and not any(fp in diff_line for fp in self.FALSE_POSITIVE_SUBSTRINGS):
+            return set(directory for directory in self.DIRS_TO_CHECK if directory in diff_line)
         else:
             return set()
 
     def on_pr_opened(self, api, payload):
-        diff = api.get_diff()
         test_dirs_with_offending_files = set()
 
-        for line in diff.split('\n'):
+        for line in self.get_diff_headers(api):
             test_dirs_with_offending_files |= self._wpt_ini_dirs(line)
 
         if test_dirs_with_offending_files:

--- a/handlers/nonini_wpt_meta/__init__.py
+++ b/handlers/nonini_wpt_meta/__init__.py
@@ -27,8 +27,8 @@ class NonINIWPTMetaFileHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         test_dirs_with_offending_files = set()
 
-        for line in api.get_changed_files():
-            test_dirs_with_offending_files |= self._wpt_ini_dirs(line)
+        for filepath in api.get_changed_files():
+            test_dirs_with_offending_files |= self._wpt_ini_dirs(filepath)
 
         if test_dirs_with_offending_files:
             if len(test_dirs_with_offending_files) == 1:

--- a/handlers/nonini_wpt_meta/__init__.py
+++ b/handlers/nonini_wpt_meta/__init__.py
@@ -27,7 +27,7 @@ class NonINIWPTMetaFileHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         test_dirs_with_offending_files = set()
 
-        for line in self.get_diff_headers(api):
+        for line in api.get_diff_headers():
             test_dirs_with_offending_files |= self._wpt_ini_dirs(line)
 
         if test_dirs_with_offending_files:

--- a/handlers/nonini_wpt_meta/__init__.py
+++ b/handlers/nonini_wpt_meta/__init__.py
@@ -27,7 +27,7 @@ class NonINIWPTMetaFileHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         test_dirs_with_offending_files = set()
 
-        for line in api.get_diff_headers():
+        for line in api.get_changed_files():
             test_dirs_with_offending_files |= self._wpt_ini_dirs(line)
 
         if test_dirs_with_offending_files:

--- a/handlers/nonini_wpt_meta/__init__.py
+++ b/handlers/nonini_wpt_meta/__init__.py
@@ -18,9 +18,11 @@ class NonINIWPTMetaFileHandler(EventHandler):
         'mozilla-sync',
     )
 
-    def _wpt_ini_dirs(self, diff_line):
-        if '.' in diff_line and not any(fp in diff_line for fp in self.FALSE_POSITIVE_SUBSTRINGS):
-            return set(directory for directory in self.DIRS_TO_CHECK if directory in diff_line)
+    def _wpt_ini_dirs(self, line):
+        if '.' in line and not any(fp in line
+                                   for fp in self.FALSE_POSITIVE_SUBSTRINGS):
+            return set(directory for directory in self.DIRS_TO_CHECK
+                       if directory in line)
         else:
             return set()
 

--- a/handlers/unsafe/__init__.py
+++ b/handlers/unsafe/__init__.py
@@ -8,11 +8,11 @@ unsafe_warning_msg = ('These commits modify **unsafe code**. '
                       'Please review it carefully!')
 
 
+
 class UnsafeHandler(EventHandler):
     def on_pr_opened(self, api, payload):
-        diff = api.get_diff()
-        for line in diff.split('\n'):
-            if is_addition(line) and line.find('unsafe ') > -1:
+        for line in self.get_added_lines(api):
+            if line.find('unsafe ') > -1:
                 self.warn(unsafe_warning_msg)
                 return
 

--- a/handlers/unsafe/__init__.py
+++ b/handlers/unsafe/__init__.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 
 from eventhandler import EventHandler
-from helpers import is_addition
 
 
 unsafe_warning_msg = ('These commits modify **unsafe code**. '
                       'Please review it carefully!')
-
 
 
 class UnsafeHandler(EventHandler):

--- a/handlers/unsafe/__init__.py
+++ b/handlers/unsafe/__init__.py
@@ -11,7 +11,7 @@ unsafe_warning_msg = ('These commits modify **unsafe code**. '
 
 class UnsafeHandler(EventHandler):
     def on_pr_opened(self, api, payload):
-        for line in self.get_added_lines(api):
+        for line in api.get_added_lines():
             if line.find('unsafe ') > -1:
                 self.warn(unsafe_warning_msg)
                 return

--- a/handlers/watchers/__init__.py
+++ b/handlers/watchers/__init__.py
@@ -23,11 +23,9 @@ class WatchersHandler(EventHandler):
         config = get_config()
         changed_files = self.get_changed_files(api)
 
-        repo = api.owner + '/' + api.repo
-        try:
-            watchers = config.items(repo)
-        except ConfigParser.NoSectionError:
-            return # No watchers
+        watchers = get_people_from_config(api, WATCHERS_CONFIG_FILE)
+        if not watchers:
+            return
 
         mentions = defaultdict(list)
         for (watcher, watched_files) in watchers:

--- a/handlers/watchers/__init__.py
+++ b/handlers/watchers/__init__.py
@@ -20,7 +20,6 @@ def build_message(mentions):
 class WatchersHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         user = payload['pull_request']['user']['login']
-        changed_files = api.get_changed_files()
 
         watchers = get_people_from_config(api, WATCHERS_CONFIG_FILE)
         if not watchers:
@@ -35,15 +34,15 @@ class WatchersHandler(EventHandler):
                     blacklisted_files.append(watched_file[1:])
             for blacklisted_file in blacklisted_files:
                 watched_files.remove('-' + blacklisted_file)
-            for changed_file in changed_files:
+            for filepath in api.get_changed_files():
                 for blacklisted_file in blacklisted_files:
-                    if changed_file.startswith(blacklisted_file):
+                    if filepath.startswith(blacklisted_file):
                         break
                 else:
                     for watched_file in watched_files:
-                        if (changed_file.startswith(watched_file) and
+                        if (filepath.startswith(watched_file) and
                                 user != watcher):
-                            mentions[watcher].append(changed_file)
+                            mentions[watcher].append(filepath)
 
         if not mentions:
             return

--- a/handlers/watchers/__init__.py
+++ b/handlers/watchers/__init__.py
@@ -20,8 +20,7 @@ def build_message(mentions):
 class WatchersHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         user = payload['pull_request']['user']['login']
-        config = get_config()
-        changed_files = self.get_changed_files(api)
+        changed_files = api.get_changed_files()
 
         watchers = get_people_from_config(api, WATCHERS_CONFIG_FILE)
         if not watchers:

--- a/helpers.py
+++ b/helpers.py
@@ -23,13 +23,6 @@ def get_collaborators(api):
     return [username for (username, _) in config_items]
 
 
-def is_addition(diff_line):
-    """
-    Checks if a line from a unified diff is an addition.
-    """
-    return diff_line.startswith('+') and not diff_line.startswith('+++')
-
-
 def linear_search(sequence, element, callback=lambda thing: thing):
     '''
     The 'in' operator also does a linear search over a sequence, but it checks

--- a/helpers.py
+++ b/helpers.py
@@ -7,6 +7,9 @@ COLLABORATORS_CONFIG_FILE = os.path.join(os.path.dirname(__file__),
                                          'collaborators.ini')
 
 
+_test_path_roots = ['a/', 'b/']
+
+
 def get_people_from_config(api, config_abs_path):
     config = ConfigParser.ConfigParser()
     config.read(config_abs_path)
@@ -23,13 +26,29 @@ def get_collaborators(api):
     return [username for (username, _) in config_items]
 
 
+def is_addition(diff_line):
+    """
+    Checks if a line from a unified diff is an addition.
+    """
+    return diff_line.startswith('+') and not diff_line.startswith('+++')
+
+
+def normalize_file_path(filepath):
+    if filepath is None or filepath.strip() == '':
+        return None
+    for prefix in _test_path_roots:
+        if filepath.startswith(prefix):
+            return filepath[len(prefix):]
+    return filepath
+
+
 def linear_search(sequence, element, callback=lambda thing: thing):
-    '''
+    """
     The 'in' operator also does a linear search over a sequence, but it checks
     for the exact match of the given object, whereas this makes use of '==',
     which calls the '__eq__' magic method, which could've been overridden in
     a custom class (which is the case for our test lint)
-    '''
+    """
     for thing in sequence:
         if element == thing:    # element could have an overridden '__eq__'
             callback(thing)

--- a/helpers.py
+++ b/helpers.py
@@ -34,8 +34,13 @@ def is_addition(diff_line):
 
 
 def normalize_file_path(filepath):
+    """
+    Strip any leading/training whitespace.
+    Remove any test directories from the start of the path
+    """
     if filepath is None or filepath.strip() == '':
         return None
+    filepath = filepath.strip()
     for prefix in _test_path_roots:
         if filepath.startswith(prefix):
             return filepath[len(prefix):]

--- a/newpr.py
+++ b/newpr.py
@@ -16,8 +16,7 @@ from StringIO import StringIO
 import urllib2
 
 import eventhandler
-
-_test_path_roots = ['a/', 'b/']
+from helpers import is_addition, normalize_file_path
 
 DIFF_HEADER_LINE_START = 'diff --git '
 
@@ -71,31 +70,15 @@ class APIProvider(object):
                 changed_files.extend(line.split(DIFF_HEADER_LINE_START)[-1].split(' '))
 
             # And get unique values using `set()`
-            self.changed_files = set(f for f in map(APIProvider.normalize_file_path, changed_files) if f is not None)
+            self.changed_files = set(f for f in map(normalize_file_path, changed_files) if f is not None)
         return self.changed_files
 
     def get_added_lines(self):
         diff = self.get_diff()
         for line in diff.splitlines():
-            if self.is_addition(line):
+            if is_addition(line):
                 # prefix of one or two pluses (+)
                 yield line
-
-    @staticmethod
-    def is_addition(diff_line):
-        """
-        Checks if a line from a unified diff is an addition.
-        """
-        return diff_line.startswith('+') and not diff_line.startswith('+++')
-
-    @staticmethod
-    def normalize_file_path(filepath):
-        if filepath is None or filepath.strip() == '':
-            return None
-        for prefix in _test_path_roots:
-            if filepath.startswith(prefix):
-                return filepath[len(prefix):]
-        return filepath
 
 
 class GithubAPIProvider(APIProvider):

--- a/newpr.py
+++ b/newpr.py
@@ -18,7 +18,7 @@ import urllib2
 import eventhandler
 from helpers import is_addition, normalize_file_path
 
-DIFF_HEADER_LINE_START = 'diff --git '
+DIFF_HEADER_PREFIX = 'diff --git '
 
 
 class APIProvider(object):
@@ -60,17 +60,19 @@ class APIProvider(object):
     def get_diff_headers(self):
         diff = self.get_diff()
         for line in diff.splitlines():
-            if line.startswith(DIFF_HEADER_LINE_START):
+            if line.startswith(DIFF_HEADER_PREFIX):
                 yield line
 
     def get_changed_files(self):
         if self.changed_files is None:
             changed_files = []
             for line in self.get_diff_headers():
-                changed_files.extend(line.split(DIFF_HEADER_LINE_START)[-1].split(' '))
+                files = line.split(DIFF_HEADER_PREFIX)[-1].split(' ')
+                changed_files.extend(files)
 
             # And get unique values using `set()`
-            self.changed_files = set(f for f in map(normalize_file_path, changed_files) if f is not None)
+            normalized = map(normalize_file_path, changed_files)
+            self.changed_files = set(f for f in normalized if f is not None)
         return self.changed_files
 
     def get_added_lines(self):

--- a/newpr.py
+++ b/newpr.py
@@ -77,9 +77,16 @@ class APIProvider(object):
     def get_added_lines(self):
         diff = self.get_diff()
         for line in diff.splitlines():
-            if line.startswith('+') and not line.startswith('+++'):
+            if self.is_addition(line):
                 # prefix of one or two pluses (+)
                 yield line
+
+    @staticmethod
+    def is_addition(diff_line):
+        """
+        Checks if a line from a unified diff is an addition.
+        """
+        return diff_line.startswith('+') and not diff_line.startswith('+++')
 
     @staticmethod
     def normalize_file_path(filepath):


### PR DESCRIPTION
Moves diff header parsing logic out of the handlers and into the `APIProvider` class. This allows the code to be reused, reduces the amount of code to maintain, and simplifies the handlers' logic

Fixes #47 