### PR TITLE
JSON cleaner should properly handle lists

### DIFF
--- a/test.py
+++ b/test.py
@@ -73,7 +73,7 @@ def create_test(filename, initial, expected,
 
 
 def run_tests(tests, warn=True, overwrite=False):
-    failed = 0
+    failed, dirty = 0, 0
     for handler, test in tests:
         eventhandler.reset_test_state()
 
@@ -108,7 +108,7 @@ def run_tests(tests, warn=True, overwrite=False):
                 if wrapper.unused and not overwrite:
                     error = '\033[91m%s\033[0m: The file has %s unused nodes'
                     print(error % (test['filename'], wrapper.unused))
-                    failed += 1
+                    dirty += 1
 
                 if overwrite:   # useful for cleaning up the tests locally
                     clean_dict = test['dict']
@@ -129,10 +129,7 @@ def run_tests(tests, warn=True, overwrite=False):
             print(error)
             failed += 1
 
-    print('Ran %d tests, %d failed' % (len(tests), failed))
-
-    if failed:
-        sys.exit(1)
+    return failed, dirty
 
 
 def register_tests(path):
@@ -183,4 +180,12 @@ if __name__ == "__main__":
     overwrite = True if 'write' in args else False
 
     tests = setup_tests()
-    run_tests(tests, not overwrite, overwrite)
+    failed, dirty = run_tests(tests, not overwrite, overwrite)
+
+    print('Ran %d tests, %d failed, %d file(s) dirty' %
+          (len(tests), failed, dirty))
+
+    if failed or dirty:
+        if dirty:
+            print('Run `python %s write` to cleanup the dirty files' % args)
+        sys.exit(1)


### PR DESCRIPTION
#100 revealed a bug in our JSON cleaner. It worked well so far, because almost all the stuff we have in those test JSONs are key/value pairs. We currently detect unused nodes by marking the used ones whenever we do a `__getitem__`. We don't mark them while iterating, because (almost all the time), we're iterating to find the key/value pairs or list items, and so we'll end up marking a lot of nodes which will otherwise be unused.

Currently, we have two problems. Firstly, a payload can have lists (search results, for example), where we can do a great deal of things like list comprehension, mapping, etc. and get the objects. 

Say, we do something like `[issue['number'] for issue in issues]`. Now, `issue['number']` will be marked (because we do a `getitem`), but the individual list items won't be marked (because we're iterating), and the end result is that the cleaner will report the node as unused. So, the idea is to assign a root node for each node, and whenever we mark the child node, we mark the parent node (and whichever ancestors aren't marked).

Secondly, we pop an unused node when we do the cleanup, but when it comes to lists, the length of the list is reduced, and we get an `IndexError` while popping. This PR fixes both!