### PR TITLE
 Do not notify watcher when watcher is PR author (fixes issue #128)

### DIFF
--- a/handlers/watchers/__init__.py
+++ b/handlers/watchers/__init__.py
@@ -19,6 +19,7 @@ def build_message(mentions):
 
 class WatchersHandler(EventHandler):
     def on_pr_opened(self, api, payload):
+        user = payload['pull_request']['user']['login']
         diff = api.get_diff()
         changed_files = []
         for line in diff.split('\n'):
@@ -49,7 +50,8 @@ class WatchersHandler(EventHandler):
                         break
                 else:
                     for watched_file in watched_files:
-                        if changed_file.startswith(watched_file):
+                        if (changed_file.startswith(watched_file) and
+                                user != watcher):
                             mentions[watcher].append(changed_file)
 
         if not mentions:

--- a/handlers/watchers/tests/new_pr_author_is_not_watcher.json
+++ b/handlers/watchers/tests/new_pr_author_is_not_watcher.json
@@ -2,61 +2,64 @@
   "expected": [
     {
       "comments": 1
-    }, 
+    },
     {
       "comments": 1
-    }, 
+    },
     {
       "comments": 0
-    }, 
+    },
     {
       "comments": 1
-    }, 
+    },
     {
       "comments": 0
-    }, 
+    },
     {
       "comments": 1
-    }, 
+    },
     {
       "comments": 1
     }
-  ], 
+  ],
   "initial": [
     {
       "diff": "diff --git a/watched/dir/file.rs b/watched/dir/file.rs"
-    }, 
+    },
     {
       "diff": "diff --git a/watched/dir/file.rs /dev/null"
-    }, 
+    },
     {
       "diff": "diff --git a/not-watched/dir/not-watched-file.rs b/not-watched/dir/not-watched-file.rs"
-    }, 
+    },
     {
       "diff": "diff --git a/not-watched/dir/not-watched-file.rs b/not-watched/dir/watched-file.rs"
-    }, 
+    },
     {
       "diff": "diff --git a/blacklisted/dir/watched-file.rs b/blacklisted/dir/watched-file.rs"
-    }, 
+    },
     {
       "diff": "diff --git a/watched/dir/blacklisted-file.rs b/watched/dir/file.rs"
-    }, 
+    },
     {
       "diff": "diff --git a/watched/dir/file.rs b/watched/dir/blacklisted-file.rs"
     }
-  ], 
+  ],
   "payload": {
-    "number": 7076, 
+    "number": 7076,
     "pull_request": {
       "base": {
         "repo": {
           "owner": {
             "login": "servo"
-          }, 
+          },
           "name": "highfive-test"
         }
+      },
+      "user": {
+        "login": "not_a_watcher"
       }
-    }, 
+    },
     "action": "opened"
   }
 }

--- a/handlers/watchers/tests/new_pr_author_is_watcher.json
+++ b/handlers/watchers/tests/new_pr_author_is_watcher.json
@@ -1,0 +1,65 @@
+{
+  "expected": [
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    }, 
+    {
+      "comments": 0
+    }, 
+    {
+      "comments": 0
+    }
+  ], 
+  "initial": [
+    {
+      "diff": "diff --git a/watched/dir/file.rs b/watched/dir/file.rs"
+    },
+    {
+      "diff": "diff --git a/watched/dir/file.rs /dev/null"
+    },
+    {
+      "diff": "diff --git a/not-watched/dir/not-watched-file.rs b/not-watched/dir/not-watched-file.rs"
+    },
+    {
+      "diff": "diff --git a/not-watched/dir/not-watched-file.rs b/not-watched/dir/watched-file.rs"
+    },
+    {
+      "diff": "diff --git a/blacklisted/dir/watched-file.rs b/blacklisted/dir/watched-file.rs"
+    }, 
+    {
+      "diff": "diff --git a/watched/dir/blacklisted-file.rs b/watched/dir/file.rs"
+    }, 
+    {
+      "diff": "diff --git a/watched/dir/file.rs b/watched/dir/blacklisted-file.rs"
+    }
+  ], 
+  "payload": {
+    "number": 7076, 
+    "pull_request": {
+      "base": {
+        "repo": {
+          "owner": {
+            "login": "servo"
+          }, 
+          "name": "highfive-test"
+        }
+      },
+      "user": {
+        "login": "test_user"
+      }
+    }, 
+    "action": "opened"
+  }
+}


### PR DESCRIPTION
   - In /handlers/watchers/__init__.py check user:{login:} against watcher for a file/directory
   - Added a new test, new_pr_author_is_watcher.json with test_user as the PR author; Assumed that a file/directory will only have 1 watcher, otherwise some tests would fail.
   - Modified the existing test to include the :user and :login in the payload; Renamed to new_pr_author_not_a_watcher.json