### PR TITLE
status-update: Don't comment when there are pushes

### DIFF
--- a/handlers/status_update/__init__.py
+++ b/handlers/status_update/__init__.py
@@ -4,8 +4,6 @@ import time
 
 from eventhandler import EventHandler
 
-PR_UPDATE_MSG = "New code was committed to pull request."
-
 
 def manage_pr_state(api, payload):
     labels = api.get_labels()
@@ -29,9 +27,6 @@ def manage_pr_state(api, payload):
 
         if mergeable:
             api.remove_label("S-needs-rebase")
-
-    if payload["action"] == "synchronize":
-        api.post_comment(PR_UPDATE_MSG)
 
 
 class StatusUpdateHandler(EventHandler):

--- a/handlers/status_update/tests/synchronize_changes.json
+++ b/handlers/status_update/tests/synchronize_changes.json
@@ -1,20 +1,20 @@
 {
   "expected": {
-    "comments": 1
-  }, 
-  "initial": {}, 
+    "comments": 0
+  },
+  "initial": {},
   "payload": {
-    "number": 7062, 
+    "number": 7062,
     "pull_request": {
       "base": {
         "repo": {
           "owner": {
             "login": "servo"
-          }, 
+          },
           "name": "servo"
         }
       }
-    }, 
+    },
     "action": "synchronize"
   }
 }


### PR DESCRIPTION
GitHub has started to send emails when commits are pushed.

If there's any other reason for keeping it, happy to close it :)