### PR TITLE
Don't warn if files with tests for bindings are modified

### DIFF
--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -9,6 +9,17 @@ TEST_REQUIRED_MSG = ('These commits modify {} code, but no tests are modified.'
 class MissingTestHandler(EventHandler):
     COMPONENT_DIRS_TO_CHECK = ('layout', 'script', 'gfx', 'style', 'net')
     TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit')
+    TEST_FILES_TO_CHECK = [
+        '{0}/{1}'.format('components/script/dom', test_file)
+        for test_file in ['testbinding.rs',
+                          'webidls/TestBinding.webidl',
+                          'testbindingproxy.rs',
+                          'webidls/TestBindingProxy.webidl',
+                          'testbindingiterable.rs',
+                          'webidls/TestBindingIterable.webidl',
+                          'testbindingpairiterable.rs',
+                          'webidls/TestBindingPairIterable.webidl']
+        ]
 
     def on_pr_opened(self, api, payload):
         components_changed = set()
@@ -20,6 +31,10 @@ class MissingTestHandler(EventHandler):
 
             for directory in self.TEST_DIRS_TO_CHECK:
                 if 'tests/{0}'.format(directory) in filepath:
+                    return
+
+            for test_file in self.TEST_FILES_TO_CHECK:
+                if test_file in filepath:
                     return
 
         if components_changed:

--- a/handlers/missing_test/tests/test_binding.json
+++ b/handlers/missing_test/tests/test_binding.json
@@ -1,0 +1,68 @@
+{
+  "initial": [
+    {
+      "diff": "diff --git components/script/dom/testbinding.rs"
+    },
+    {
+      "diff": "diff --git components/script/dom/webidls/TestBinding.webidl"
+    },
+    {
+      "diff": "diff --git components/script/dom/testbindingproxy.rs"
+    },
+    {
+      "diff": "diff --git components/script/dom/webidls/TestBindingProxy.webidl"
+    },
+    {
+      "diff": "diff --git components/script/dom/testbindingiterable.rs"
+    },
+    {
+      "diff": "diff --git components/script/dom/webidls/TestBindingIterable.webidl"
+    },
+    {
+      "diff": "diff --git components/script/dom/testbindingpairiterable.rs"
+    },
+    {
+      "diff": "diff --git components/script/dom/webidls/TestBindingPairIterable.webidl"
+    }
+  ],
+  "expected": [
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    },
+    {
+      "comments": 0
+    }
+  ],
+  "payload": {
+    "number": 10355,
+    "pull_request": {
+      "base": {
+        "repo": {
+          "owner": {
+            "login": "servo"
+          },
+          "name": "servo"
+        }
+      }
+    },
+    "action": "opened"
+  }
+}


### PR DESCRIPTION
I can't say I really understood how the tests work--hard to tell what's being tested when there's no live repository--, but I went ahead and added one anyway. Fixes #49.