### PR TITLE
also check 'compiletest/plugin/compile-fail' test dir on a new PR

### DIFF
--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -8,7 +8,8 @@ TEST_REQUIRED_MSG = ('These commits modify {} code, but no tests are modified.'
 
 class MissingTestHandler(EventHandler):
     COMPONENT_DIRS_TO_CHECK = ('layout', 'script', 'gfx', 'style', 'net')
-    TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit', 'compiletest/plugin/compile-fail')
+    TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit',
+                          'compiletest/plugin/compile-fail')
     TEST_FILES_TO_CHECK = [
         '{0}/{1}'.format('components/script/dom', test_file)
         for test_file in ['testbinding.rs',

--- a/handlers/missing_test/__init__.py
+++ b/handlers/missing_test/__init__.py
@@ -8,7 +8,7 @@ TEST_REQUIRED_MSG = ('These commits modify {} code, but no tests are modified.'
 
 class MissingTestHandler(EventHandler):
     COMPONENT_DIRS_TO_CHECK = ('layout', 'script', 'gfx', 'style', 'net')
-    TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit')
+    TEST_DIRS_TO_CHECK = ('ref', 'wpt', 'unit', 'compiletest/plugin/compile-fail')
     TEST_FILES_TO_CHECK = [
         '{0}/{1}'.format('components/script/dom', test_file)
         for test_file in ['testbinding.rs',

--- a/handlers/missing_test/tests/new_pr.json
+++ b/handlers/missing_test/tests/new_pr.json
@@ -29,6 +29,9 @@
     }, 
     {
       "comments": 0
+    },
+    {
+      "comments": 0
     }
   ], 
   "initial": [
@@ -61,6 +64,9 @@
     }, 
     {
       "diff": "diff --git components/script/\ndiff --git tests/unit"
+    }, 
+    {
+      "diff": "diff --git components/script/\ndiff --git tests/compiletest/plugin/compile-fail"
     }
   ], 
   "payload": {


### PR DESCRIPTION
This addresses issue #167 - Let me know if you'd rather not slam the entire sub-dir path in `TEST_DIRS_TO_CHECK` and instead do something like COMPILE_TEST_DIRS_TO_CHECK 