### PR TITLE
Don't annoy label watchers

### DIFF
--- a/handlers/label_watchers/tests/dont_annoy.json
+++ b/handlers/label_watchers/tests/dont_annoy.json
@@ -4,13 +4,19 @@
   },
   "initial": {},
   "payload": {
+    "action": "labeled",
     "issue": {
-      "number": 123,
-      "labels": [{
-        "name": "L-python"
-      }],
+      "labels": [
+        {
+          "name": "A-mach"
+        },
+        {
+          "name": "L-python"
+        }
+      ],
+      "number": 16179,
       "user": {
-        "login": "Wafflespeanut"
+        "login": "jdm"
       }
     },
     "sender": {
@@ -23,8 +29,7 @@
       "name": "servo"
     },
     "label": {
-      "name": "L-python"
-    },
-    "action": "labeled"
+      "name": "A-mach"
+    }
   }
 }

--- a/handlers/label_watchers/tests/dont_label_sender.json
+++ b/handlers/label_watchers/tests/dont_label_sender.json
@@ -1,23 +1,26 @@
 {
   "expected": {
     "comments": 0
-  }, 
-  "initial": {}, 
+  },
+  "initial": {},
   "payload": {
     "sender": {
       "login": "jdm"
-    }, 
+    },
     "repository": {
       "owner": {
         "login": "servo"
-      }, 
+      },
       "name": "highfive"
-    }, 
+    },
     "label": {
       "name": "enhancement"
-    }, 
-    "action": "labeled", 
+    },
+    "action": "labeled",
     "issue": {
+      "labels": [{
+        "name": "enhancement"
+      }],
       "number": 84,
       "user": {
         "login": "nox"

--- a/handlers/label_watchers/tests/new_pr.json
+++ b/handlers/label_watchers/tests/new_pr.json
@@ -1,24 +1,27 @@
 {
   "expected": {
     "comments": 1
-  }, 
-  "initial": {}, 
+  },
+  "initial": {},
   "payload": {
     "sender": {
       "login": "test"
-    }, 
+    },
     "repository": {
       "owner": {
         "login": "servo"
-      }, 
+      },
       "name": "highfive"
-    }, 
+    },
     "label": {
       "name": "enhancement"
-    }, 
-    "action": "labeled", 
+    },
+    "action": "labeled",
     "issue": {
       "number": 84,
+      "labels": [{
+        "name": "enhancement"
+      }],
       "user": {
         "login": "highfive"
       }

--- a/handlers/label_watchers/tests/not_watched.json
+++ b/handlers/label_watchers/tests/not_watched.json
@@ -1,24 +1,27 @@
 {
   "expected": {
     "comments": 0
-  }, 
-  "initial": {}, 
+  },
+  "initial": {},
   "payload": {
     "sender": {
       "login": "jdm"
-    }, 
+    },
     "repository": {
       "owner": {
         "login": "servo"
-      }, 
+      },
       "name": "highfive"
-    }, 
+    },
     "label": {
       "name": "not-watched-label"
-    }, 
-    "action": "labeled", 
+    },
+    "action": "labeled",
     "issue": {
       "number": 84,
+      "labels": [{
+        "name": "not-watched-label"
+      }],
       "user": {
         "login": "Wafflespeanut"
       }

--- a/json_cleanup.py
+++ b/json_cleanup.py
@@ -52,8 +52,16 @@ class NodeMarker(object):
         self._node[key].mark()      # it will be marked as used!
         return self._node[key]
 
+    def get(self, key, default=None):
+        if key in self._node:
+            self._node[key].mark()
+        return self._node.get(key, default)
+
     def __setitem__(self, key, val):
         self._node[key] = visit_nodes(val)
+
+    def __hash__(self):
+        return hash(self._node)
 
     def __iter__(self):
         return iter(self._node)
@@ -71,14 +79,14 @@ class NodeMarker(object):
         return self._node % self.get_object(other)
 
     def __contains__(self, other):
-        stuff = self.get_object(other)
+        other = self.get_object(other)
         # since string is also a sequence in python, we shouldn't iterate
         # over it and check the individual characters
         if isinstance(self._node, str) or isinstance(self._node, unicode):
             return other in self._node
 
         for idx, thing in enumerate(self._node):
-            if thing == stuff:
+            if thing == other:
                 if isinstance(self._node, list):
                     self._node[idx].mark()
                 else:


### PR DESCRIPTION
Highfive currently *annoys* label watchers by cc'ing them multiple times if an issue has the labels they watch (like [this](https://github.com/servo/servo/issues/16171#issuecomment-289876982) for example, and I think I'm the victim most of the time). This PR is a fix for that.