### PR TITLE
Support custom label actions per repository

### DIFF
--- a/handlers/status_update/__init__.py
+++ b/handlers/status_update/__init__.py
@@ -1,16 +1,32 @@
 from __future__ import absolute_import
 
+import ConfigParser
+import os.path
 import time
 
 from eventhandler import EventHandler
 
 
+config = ConfigParser.SafeConfigParser()
+config.optionxform = str  # Be case sensitive
+config.read(os.path.join(os.path.dirname(__file__), 'labels.ini'))
+config = {
+    repo: {
+        event: set(labels.split(' ')) for event, labels in config.items(repo)
+    }
+    for repo in config.sections()
+}
+# TODO(aneeshusa): Add checking of config option validity
+
+
 def manage_pr_state(api, payload):
     labels = api.get_labels()
 
-    for label in ["S-awaiting-merge",
-                  "S-tests-failed",
-                  "S-needs-code-changes"]:
+    for label in [
+        "S-awaiting-merge",
+        "S-tests-failed",
+        "S-needs-code-changes"
+    ]:
         if label in labels:
             api.remove_label(label)
     if "S-awaiting-review" not in labels:
@@ -29,16 +45,33 @@ def manage_pr_state(api, payload):
             api.remove_label("S-needs-rebase")
 
 
+def handle_custom_labels(api, event):
+        repo_config = config.get('{}/{}'.format(api.owner, api.repo), None)
+        if not repo_config:
+            return
+        labels = api.get_labels()
+        for label in repo_config.get('remove_on_pr_{}'.format(event), []):
+            if label in labels:
+                api.remove_label(label)
+        for label in repo_config.get('add_on_pr_{}'.format(event), []):
+            if label not in labels:
+                api.add_label(label)
+
+
 class StatusUpdateHandler(EventHandler):
     def on_pr_opened(self, api, payload):
         manage_pr_state(api, payload)
+        handle_custom_labels(api, 'opened')
 
     def on_pr_updated(self, api, payload):
         manage_pr_state(api, payload)
+        handle_custom_labels(api, 'updated')
 
     def on_pr_closed(self, api, payload):
+        handle_custom_labels(api, 'closed')
         if payload['pull_request']['merged']:
             api.remove_label("S-awaiting-merge")
+            handle_custom_labels(api, 'merged')
 
 
 handler_interface = StatusUpdateHandler

--- a/handlers/status_update/labels.ini
+++ b/handlers/status_update/labels.ini
@@ -1,0 +1,2 @@
+[servo/saltfs]
+add_on_pr_merged = S-needs-deploy

--- a/handlers/status_update/tests/custom_labels.json
+++ b/handlers/status_update/tests/custom_labels.json
@@ -1,0 +1,27 @@
+{
+  "expected": {
+    "labels": [
+      "S-needs-deploy"
+    ]
+  },
+  "initial": {
+    "labels": [
+      "S-awaiting-merge"
+    ]
+  },
+  "payload": {
+    "number": 659,
+    "pull_request": {
+      "base": {
+        "repo": {
+          "owner": {
+            "login": "servo"
+          },
+          "name": "saltfs"
+        }
+      },
+      "merged": true
+    },
+    "action": "closed"
+  }
+}


### PR DESCRIPTION
When events occur on a PR (open, close, merge, etc.),
support adding or removing custom labels through a new config file,
with per-repository settings.

The driving use case for this is to add `S-needs-deploy` to merged
PRs in the saltfs repository to keep track of what's been deployed.

Fixes #179.