### PR TITLE
Use test data in label watcher test

### DIFF
--- a/handlers/label_watchers/tests/dont_annoy.json
+++ b/handlers/label_watchers/tests/dont_annoy.json
@@ -8,10 +8,10 @@
     "issue": {
       "labels": [
         {
-          "name": "A-mach"
+          "name": "foo"
         },
         {
-          "name": "L-python"
+          "name": "bar"
         }
       ],
       "number": 16179,
@@ -26,10 +26,10 @@
       "owner": {
         "login": "servo"
       },
-      "name": "servo"
+      "name": "highfive-test"
     },
     "label": {
-      "name": "A-mach"
+      "name": "foo"
     }
   }
 }

--- a/handlers/label_watchers/watchers.ini
+++ b/handlers/label_watchers/watchers.ini
@@ -6,3 +6,6 @@ emilio = A-stylo
 
 [servo/highfive]
 jdm = enhancement
+
+[servo/highfive-test]
+test_user = foo bar


### PR DESCRIPTION
This test was using the actual servo repo data and tests were failing because of this in #182. Converted these to test data to prevent these kind of failures.