### PR TITLE
Make @ optional in "r? username" comments

### DIFF
--- a/handlers/assign_reviewer/__init__.py
+++ b/handlers/assign_reviewer/__init__.py
@@ -15,7 +15,7 @@ def find_reviewer(comment):
     If the user specified a reviewer, return the username,
     otherwise returns None.
     """
-    reviewer = re.search(r'.*r\?[:\- ]*@([a-zA-Z0-9\-]*)', str(comment))
+    reviewer = re.search(r'.*r\?[:\- ]*@?([a-zA-Z0-9\-]+)', str(comment))
     if reviewer:
         return reviewer.group(1)
     return None


### PR DESCRIPTION
This allows PR descriptions to include instructions like "r? mbrubeck" without sending extraneous email when the PR is merged to other repos.