### PR TITLE
Update the easy info message to include zulip link

### DIFF
--- a/handlers/easy_info/__init__.py
+++ b/handlers/easy_info/__init__.py
@@ -5,8 +5,8 @@ import re
 ASSIGN_MSG = 'assign me'
 
 MSG = ('Hi! If you have any questions regarding this issue, feel free to make'
-       ' a comment here, or ask it in the `#servo` channel in '
-       '[Matrix](https://wiki.mozilla.org/Matrix).\n\n'
+       ' a comment here, or ask it in '
+       '[Zulip](https://servo.zulipchat.com/).\n\n'
        'If you intend to work on this issue, then add `@%s: %s`'
        ' to your comment, and I\'ll assign this to you. :smile:')
 


### PR DESCRIPTION
This PR updates the message to include a Zulip link and removes the Matrix link.