### PR TITLE
Set assignee upon request.

### DIFF
--- a/handlers/easy_info/__init__.py
+++ b/handlers/easy_info/__init__.py
@@ -39,6 +39,7 @@ class EasyInfoHandler(EventHandler):
                 return
 
             api.add_label('C-assigned')
+            api.set_assignee(user)
             api.post_comment(RESPONSE_OK % user)
 
 


### PR DESCRIPTION
Fixes #220. This didn't used to be possible for users who were not members of the organization, but now it is!