### PR TITLE
watcher: Subscribe jschwe to deny.toml in servo/servo

### DIFF
--- a/handlers/watchers/watchers.ini
+++ b/handlers/watchers/watchers.ini
@@ -1,5 +1,6 @@
 [servo/servo]
 emilio =
+jschwe = deny.toml
 
 [servo/highfive]
 jdm =


### PR DESCRIPTION
I'd like to be notified for changes to deny.toml, since activities like ignoring security advisories or adding new allowed licenses are of interest to me.